### PR TITLE
Fix misisng icon in multi eclipse desktop entry

### DIFF
--- a/pkgs/multiEclipse/default.nix
+++ b/pkgs/multiEclipse/default.nix
@@ -54,6 +54,8 @@ in symlinkJoin {
     ''
       mkdir -p $out/share/applications
       cp ${desktopItem}/share/applications/* $out/share/applications
+      mkdir -p $out/share/pixmaps
+      ln -s ${builtins.elemAt myEclipsePackages 0}/share/pixmaps/eclipse.xpm $out/share/pixmaps/eclipse.xpm
     '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
It appears, that only the icons from a package directly in the system path can be used.